### PR TITLE
add rust cxx example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-/crusttest/target
+/bindings/rust/target
+/bindings/rust_cxx/target
+build
 Cargo.lock
 .cache

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ cd binding/rust
 cargo run justadummystring
 ```
 
+#### Alternative example of rust <-> c++ bindings using cxx create
+
+You can use the rust cxx crate to create direct bindings between c++ and rust without intermediate C wrappers
+
+```
+cd bindings/rust_cxx
+cargo run
+```
+
 ### Build and Run Zig client
 
 Install [Zig](https://ziglang.org/) compiler first

--- a/bindings/rust_cxx/Cargo.toml
+++ b/bindings/rust_cxx/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust_cxx"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cxx = "1.0.94"
+
+[build-dependencies]
+cxx-build = "1.0.94"

--- a/bindings/rust_cxx/build.rs
+++ b/bindings/rust_cxx/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    cxx_build::bridge("src/main.rs") // returns a cc::Build
+        .file("cppdemo/demo.cpp")
+        .flag_if_supported("-std=c++14")
+        .compile("cppdemo-bridge");
+
+    println!("cargo:rerun-if-changed=src/main.rs");
+    println!("cargo:rerun-if-changed=cppdemo/demo.cpp");
+    println!("cargo:rerun-if-changed=cppdemo/demo.hpp");
+}

--- a/bindings/rust_cxx/cppdemo/CMakeLists.txt
+++ b/bindings/rust_cxx/cppdemo/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16.3)
+
+project(cppdemo)
+
+add_library( cppdemo demo.cpp )
+add_executable ( cppdemorun main.cpp )
+target_link_libraries( cppdemorun cppdemo )

--- a/bindings/rust_cxx/cppdemo/demo.cpp
+++ b/bindings/rust_cxx/cppdemo/demo.cpp
@@ -1,0 +1,9 @@
+#include "demo.hpp"
+#include <iostream>
+Demo::Demo() {}
+
+Demo::~Demo() {}
+
+void Demo::demo_do() const { std::cout << "Hello from Demo" << std::endl; }
+
+std::unique_ptr<Demo> new_demo() { return std::make_unique<Demo>(); }

--- a/bindings/rust_cxx/cppdemo/demo.hpp
+++ b/bindings/rust_cxx/cppdemo/demo.hpp
@@ -1,0 +1,20 @@
+#include <string>
+#include <memory>
+
+class Demo{
+public:
+    Demo();
+    Demo(Demo &&) = default;
+    Demo(const Demo &) = default;
+    Demo &operator=(Demo &&) = default;
+    Demo &operator=(const Demo &) = default;
+    ~Demo();
+
+    void demo_do() const;
+
+private:
+    
+};
+
+
+std::unique_ptr<Demo> new_demo();

--- a/bindings/rust_cxx/cppdemo/main.cpp
+++ b/bindings/rust_cxx/cppdemo/main.cpp
@@ -1,0 +1,7 @@
+#include "demo.hpp"
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  auto demo = new_demo();
+  demo->demo_do();
+}

--- a/bindings/rust_cxx/src/main.rs
+++ b/bindings/rust_cxx/src/main.rs
@@ -1,0 +1,15 @@
+#[cxx::bridge]
+mod ffi {
+    unsafe extern "C++" {
+        include!("rust_cxx/cppdemo/demo.hpp");
+
+        type Demo;
+        fn new_demo() -> UniquePtr<Demo>;
+        fn demo_do(self: &Demo);
+    }
+}
+
+fn main() {
+    let demo = ffi::new_demo();
+    demo.as_ref().unwrap().demo_do();
+}


### PR DESCRIPTION
You are are interested here is another example of binding c++ code to rust. This time with the cxx crate. This way you can avoid writing intermediate C wrappers.